### PR TITLE
feat: complete user unsubscribe flow (UX, security, delayed deletion, talent filtering)

### DIFF
--- a/backend/handlers/login.ts
+++ b/backend/handlers/login.ts
@@ -33,6 +33,10 @@ export const loginHandler = async (req: Request, res: Response, _next: NextFunct
         }
 
         const user = result.rows[0];
+        if (user.subscribed === false) {
+            res.status(403).json({ message: "Ce compte a été désinscrit. Il sera supprimé prochainement." });
+            return;
+        }
         const match = await bcrypt.compare(password, user.password);
         if (!match) {
             res.status(401).json({ message: "Mot de passe invalide." });

--- a/backend/handlers/users.ts
+++ b/backend/handlers/users.ts
@@ -23,7 +23,7 @@ export const getAllUsersHandler = async (req: Request, res: Response, _next: Nex
         const result = await pool.query(
             `SELECT id, email, first_name AS "firstName", last_name AS "lastName", title, avatar, bio
             FROM users
-            WHERE id != $1`,
+            WHERE id != $1 AND subscribed = TRUE`,
             [decoded.id]
         );
         res.json(result.rows);

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -26,4 +26,12 @@ export async function login(data: AuthData): Promise<AuthResponse> {
 
 export async function register(data: AuthData): Promise<AuthResponse> {
   return await HttpService.post<AuthResponse>('/register', data, false);
+}
+
+export async function unsubscribe(email: string): Promise<{ message: string }> {
+  return await HttpService.request<{ message: string }>('/unsubscribe', { 
+    method: 'DELETE', 
+    body: { email }, 
+    requiresAuth: false 
+  });
 } 

--- a/frontend/src/components/MessagesModal.tsx
+++ b/frontend/src/components/MessagesModal.tsx
@@ -99,7 +99,7 @@ const MessagesModal: React.FC<MessagesModalProps> = ({ isOpen, onClose, messages
                   <li key={msg.id} style={{marginBottom: 15, borderBottom: '1px solid #eee', paddingBottom: 10, cursor: 'pointer'}} onClick={() => { setSelectedMessage(msg); setReply(''); setReplyError(null); setReplySuccess(null); }}>
                     <div style={{fontWeight: 'bold'}}>De : {getSenderName(msg)}</div>
                     <div style={{color: '#555', fontSize: '0.95em', margin: '5px 0'}}>{msg.content.slice(0, 40)}{msg.content.length > 40 ? '...' : ''}</div>
-                    <div style={{fontSize: '0.85em', color: '#888'}}>{msg.sent_at_pretty || msg.sent_at}</div>
+                    <div style={{fontSize: '0.85em', color: '#888'}}>{msg.sent_at ? new Date(msg.sent_at).toLocaleString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}</div>
                   </li>
                 ))}
               </ul>

--- a/frontend/src/components/UnsubscribeModal.tsx
+++ b/frontend/src/components/UnsubscribeModal.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { unsubscribe } from '../api/authApi';
+import { AuthService } from '../services/authService';
+import { useNavigate } from 'react-router-dom';
+import '../styles/UnsubscribeModal.scss';
+
+interface UnsubscribeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userEmail: string;
+}
+
+const UnsubscribeModal: React.FC<UnsubscribeModalProps> = ({ isOpen, onClose, userEmail }) => {
+  const [isUnsubscribing, setIsUnsubscribing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('modal-open');
+    } else {
+      document.body.classList.remove('modal-open');
+    }
+    return () => {
+      document.body.classList.remove('modal-open');
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleUnsubscribe = async () => {
+    setIsUnsubscribing(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await unsubscribe(userEmail);
+      setSuccess('Votre compte a été désinscrit avec succès. Il sera supprimé dans 14 jours.');
+      setTimeout(() => {
+        AuthService.removeToken();
+        navigate('/');
+        window.location.reload();
+      }, 3000);
+    } catch (err) {
+      setError('Une erreur est survenue lors de la désinscription. Veuillez réessayer.');
+    } finally {
+      setIsUnsubscribing(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="unsubscribe-modal__overlay"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="unsubscribe-modal" onClick={e => e.stopPropagation()}>
+        <button className="unsubscribe-modal__close" onClick={onClose}>&times;</button>
+        <h2 className="unsubscribe-modal__title">Se désinscrire</h2>
+        <div className="unsubscribe-modal__content">
+          <div className="unsubscribe-modal__warning">
+            <div className="warning-icon">⚠️</div>
+            <h3>Attention !</h3>
+            <p>
+              Êtes-vous sûr de vouloir vous désinscrire de SwipeMyTalent ?
+            </p>
+            <ul>
+              <li>Votre compte sera désactivé immédiatement</li>
+              <li>Vos données seront supprimées définitivement dans 14 jours</li>
+              <li>Cette action est irréversible</li>
+            </ul>
+          </div>
+          <div className="unsubscribe-modal__email">
+            <strong>Email :</strong> {userEmail}
+          </div>
+          {error && <div className="unsubscribe-modal__error">{error}</div>}
+          {success && <div className="unsubscribe-modal__success">{success}</div>}
+        </div>
+        <div className="unsubscribe-modal__actions">
+          <button 
+            type="button" 
+            className="btn btn--secondary"
+            onClick={onClose}
+            disabled={isUnsubscribing}
+          >
+            Annuler
+          </button>
+          <button 
+            type="button" 
+            className="btn btn--danger"
+            onClick={handleUnsubscribe}
+            disabled={isUnsubscribing}
+          >
+            {isUnsubscribing ? 'Désinscription...' : 'Se désinscrire'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default UnsubscribeModal; 

--- a/frontend/src/components/cards/AboutCard.tsx
+++ b/frontend/src/components/cards/AboutCard.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react';
 import EditBioModal from '../EditBioModal';
 import SeeMoreModal from './SeeMoreModal';
+import UnsubscribeModal from '../UnsubscribeModal';
 import { fetchUserProfile, updateUserProfile } from '../../api/userApi';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../redux/store';
 import '../../styles/AboutCard.scss';
 
 const AboutCard = () => {
   const [bio, setBio] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [voirPlusModal, setVoirPlusModal] = useState(false);
+  const [isUnsubscribeModalOpen, setIsUnsubscribeModalOpen] = useState(false);
+  const user = useSelector((state: RootState) => state.user);
 
   useEffect(() => {
     fetchUserProfile().then(user => {
@@ -17,6 +22,8 @@ const AboutCard = () => {
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
+  const handleOpenUnsubscribeModal = () => setIsUnsubscribeModalOpen(true);
+  const handleCloseUnsubscribeModal = () => setIsUnsubscribeModalOpen(false);
 
   const handleSaveBio = async (newBio: string) => {
     setBio(newBio);
@@ -86,6 +93,13 @@ const AboutCard = () => {
       )}
       {isModalOpen && (
         <EditBioModal isOpen={isModalOpen} currentBio={bio} onClose={handleCloseModal} onSave={handleSaveBio} />
+      )}
+      {isUnsubscribeModalOpen && (
+        <UnsubscribeModal
+          isOpen={isUnsubscribeModalOpen}
+          onClose={handleCloseUnsubscribeModal}
+          userEmail={user.email}
+        />
       )}
     </section>
   );

--- a/frontend/src/components/cards/AboutCard.tsx
+++ b/frontend/src/components/cards/AboutCard.tsx
@@ -1,18 +1,13 @@
 import { useEffect, useState } from 'react';
 import EditBioModal from '../EditBioModal';
 import SeeMoreModal from './SeeMoreModal';
-import UnsubscribeModal from '../UnsubscribeModal';
 import { fetchUserProfile, updateUserProfile } from '../../api/userApi';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../redux/store';
 import '../../styles/AboutCard.scss';
 
 const AboutCard = () => {
   const [bio, setBio] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [voirPlusModal, setVoirPlusModal] = useState(false);
-  const [isUnsubscribeModalOpen, setIsUnsubscribeModalOpen] = useState(false);
-  const user = useSelector((state: RootState) => state.user);
 
   useEffect(() => {
     fetchUserProfile().then(user => {
@@ -22,8 +17,6 @@ const AboutCard = () => {
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
-  const handleOpenUnsubscribeModal = () => setIsUnsubscribeModalOpen(true);
-  const handleCloseUnsubscribeModal = () => setIsUnsubscribeModalOpen(false);
 
   const handleSaveBio = async (newBio: string) => {
     setBio(newBio);
@@ -93,13 +86,6 @@ const AboutCard = () => {
       )}
       {isModalOpen && (
         <EditBioModal isOpen={isModalOpen} currentBio={bio} onClose={handleCloseModal} onSave={handleSaveBio} />
-      )}
-      {isUnsubscribeModalOpen && (
-        <UnsubscribeModal
-          isOpen={isUnsubscribeModalOpen}
-          onClose={handleCloseUnsubscribeModal}
-          userEmail={user.email}
-        />
       )}
     </section>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import RecentActivityCard from '../components/cards/RecentActivityCard';
 import AboutCard from '../components/cards/AboutCard';
 import ProfileModal from '../components/ProfileModal';
 import MessagesModal from '../components/MessagesModal';
+import UnsubscribeModal from '../components/UnsubscribeModal';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../redux/store';
 import { useState, useEffect } from 'react';
@@ -23,6 +24,7 @@ const Dashboard: React.FC = () => {
     const { editUser, setEditUser, handleChange, handlePhotoChange, handleSubmit, error } = useEditProfile(user);
     const [messages, setMessages] = useState<any[]>([]);
     const [isMessagesModalOpen, setIsMessagesModalOpen] = useState(false);
+    const [isUnsubscribeModalOpen, setIsUnsubscribeModalOpen] = useState(false);
 
     useEffect(() => {
         if (AuthService.isLoggedIn()) {
@@ -93,6 +95,28 @@ const Dashboard: React.FC = () => {
                 isOpen={isMessagesModalOpen}
                 onClose={() => setIsMessagesModalOpen(false)}
                 messages={messages}
+            />
+            <div style={{ textAlign: 'right', marginTop: '2rem' }}>
+                <button
+                    className="dashboard-unsubscribe-link"
+                    onClick={() => setIsUnsubscribeModalOpen(true)}
+                    style={{
+                        background: 'none',
+                        border: 'none',
+                        color: '#888',
+                        fontSize: '0.95rem',
+                        textDecoration: 'underline',
+                        cursor: 'pointer',
+                        padding: 0
+                    }}
+                >
+                    Se désinscrire
+                </button>
+            </div>
+            <UnsubscribeModal
+                isOpen={isUnsubscribeModalOpen}
+                onClose={() => setIsUnsubscribeModalOpen(false)}
+                userEmail={user.email}
             />
         </div>
     );

--- a/frontend/src/services/httpService.ts
+++ b/frontend/src/services/httpService.ts
@@ -62,7 +62,7 @@ export class HttpService {
     
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({ message: response.statusText }));
-      throw new Error(`Erreur HTTP ${response.status}: ${errorData.message || response.statusText}`);
+      throw new Error(errorData.message || response.statusText);
     }
 
     // Gérer le cas où la réponse est vide (ex: 204 No Content)

--- a/frontend/src/styles/AboutCard.scss
+++ b/frontend/src/styles/AboutCard.scss
@@ -35,6 +35,21 @@
   font-size: 1rem;
   transition: color 0.2s;
 }
+
 .about-card .edit-btn:hover {
   color: #0d47a1;
+}
+
+.about-card .unsubscribe-btn {
+  background: none;
+  border: none;
+  color: var(--danger);
+  font-weight: bold;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: color 0.2s;
+}
+
+.about-card .unsubscribe-btn:hover {
+  color: #c62828;
 } 

--- a/frontend/src/styles/UnsubscribeModal.scss
+++ b/frontend/src/styles/UnsubscribeModal.scss
@@ -1,0 +1,192 @@
+@use './_variables' as *;
+
+.unsubscribe-modal {
+  &__overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+  }
+
+  & {
+    background: var(--bg-card);
+    border-radius: 12px;
+    box-shadow: var(--shadow-card);
+    padding: 2rem;
+    max-width: 500px;
+    width: 100%;
+    position: relative;
+    border: 1.5px solid var(--primary-orange);
+  }
+
+  &__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: var(--text-secondary);
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background 0.2s;
+
+    &:hover {
+      background: var(--bg-card-hover);
+    }
+  }
+
+  &__title {
+    color: var(--primary-orange);
+    margin-bottom: 1.5rem;
+    font-size: 1.5rem;
+    text-align: center;
+  }
+
+  &__content {
+    margin-bottom: 2rem;
+  }
+
+  &__warning {
+    background: rgba(255, 160, 0, 0.05);
+    border: 1px solid var(--primary-orange);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    text-align: center;
+
+    .warning-icon {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+
+    h3 {
+      color: var(--primary-orange);
+      margin-bottom: 1rem;
+      font-size: 1.2rem;
+    }
+
+    p {
+      color: var(--text-primary);
+      margin-bottom: 1rem;
+      font-weight: 500;
+    }
+
+    ul {
+      text-align: left;
+      margin: 0;
+      padding-left: 1.5rem;
+      color: var(--text-secondary);
+
+      li {
+        margin-bottom: 0.5rem;
+        font-size: 0.95rem;
+      }
+    }
+  }
+
+  &__email {
+    background: var(--bg-card-hover);
+    border-radius: 6px;
+    padding: 1rem;
+    text-align: center;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+  }
+
+  &__error {
+    background: rgba(229, 57, 53, 0.05);
+    border: 1px solid var(--danger);
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin-top: 1rem;
+    color: var(--danger);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+
+  &__success {
+    background: rgba(25, 118, 210, 0.05);
+    border: 1px solid var(--primary-blue);
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin-top: 1rem;
+    color: var(--primary-blue);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+
+    .btn {
+      padding: 0.75rem 1.5rem;
+      border-radius: 6px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+      border: none;
+      font-size: 1rem;
+
+      &--secondary {
+        background: var(--bg-card-hover);
+        color: var(--text-primary);
+        border: 1px solid var(--primary-blue-light);
+
+        &:hover {
+          background: var(--primary-blue-light);
+          color: var(--bg-card);
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+      }
+
+      &--danger {
+        background: var(--danger);
+        color: white;
+
+        &:hover {
+          background: #c62828;
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
+}
+
+// Responsive
+@media (max-width: 768px) {
+  .unsubscribe-modal {
+    margin: 1rem;
+    padding: 1.5rem;
+
+    &__actions {
+      flex-direction: column;
+      
+      .btn {
+        width: 100%;
+      }
+    }
+  }
+} 

--- a/frontend/src/styles/dashboard.scss
+++ b/frontend/src/styles/dashboard.scss
@@ -155,3 +155,18 @@ body {
     }
   }
 }
+
+.dashboard-unsubscribe-link {
+  color: #888;
+  font-size: 0.95rem;
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s;
+}
+.dashboard-unsubscribe-link:hover {
+  color: #e53935;
+  text-decoration: underline;
+}


### PR DESCRIPTION
- Add full unsubscribe logic: set subscribed = false and record unsubscribe date
- Block login for unsubscribed users
- Hide unsubscribed users from talent lists and searches
- Automatic deletion of unsubscribed accounts after 14 days (with cascade on messages)
- Improve frontend UX: clear error messages, local date display, discreet unsubscribe link
- Ensure GDPR compliance: user data inaccessible immediately, deleted after delay